### PR TITLE
Implements migrations generator from database schema

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "saviorenato/migrations-generator",
+    "name": "migrations/migrations-generator",
     "description": "Pacote Laravel para gerar automaticamente arquivos de migrations a partir do banco de dados",
     "type": "library",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     },
     "require": {
         "php": ">=7.2",
-        "illuminate/support": "^9|^10|^11|^12"
+        "illuminate/support": "^9|^10|^11|^12",
+        "illuminate/console": "^9|^10|^11|^12"
     },
     "extra": {
         "laravel": {

--- a/src/Console/GenerateMigrationsCommand.php
+++ b/src/Console/GenerateMigrationsCommand.php
@@ -3,204 +3,29 @@
 namespace Migrations\MigrationsGenerator\Console;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
+use Migrations\MigrationsGenerator\Services\DriverSelector;
+use Illuminate\Support\Facades\Config;
 
 class GenerateMigrationsCommand extends Command
 {
     protected $signature = 'generate:migrations';
     protected $description = 'Gera arquivos de migrations automaticamente a partir do banco de dados atual (MySQL ou PostgreSQL)';
 
-    public function handle()
+    /**
+     * Execute the console command.
+     *
+     * @param DriverSelector $selector
+     * @return void
+     */
+    public function handle(DriverSelector $selector)
     {
         $this->info("Iniciando a geração de migrations...");
 
-        // Detecta o driver de conexão (mysql ou pgsql)
-        $driver = DB::connection()->getDriverName();
-
-        if ($driver === 'mysql') {
-            $databaseName = DB::getDatabaseName();
-            $tables = DB::select("SHOW TABLES");
-            $tablesKey = "Tables_in_$databaseName";
-
-            foreach ($tables as $table) {
-                $tableName = $table->$tablesKey;
-
-                // Pular a tabela de migrations
-                if ($tableName === 'migrations') {
-                    continue;
-                }
-
-                $this->info("Gerando migration para a tabela: $tableName");
-
-                // Recupera as colunas da tabela no MySQL
-                $columns = DB::select("SHOW COLUMNS FROM `$tableName`");
-                $schemaFields = "";
-
-                foreach ($columns as $column) {
-                    // Propriedades da coluna: Field, Type, Null, Key, Default, Extra
-                    $field = $column->Field;
-                    $type = $this->mapColumnType($column->Type, $driver);
-                    $nullable = ($column->Null === "YES") ? "->nullable()" : "";
-                    $default = ($column->Default !== null) ? "->default('" . addslashes($column->Default) . "')" : "";
-
-                    // Se a coluna for primary key auto-increment, use o método increments
-                    if ($column->Key === 'PRI' && strpos($column->Extra, 'auto_increment') !== false) {
-                        $schemaFields .= "\$table->increments('$field');\n\t\t\t";
-                    } else {
-                        $schemaFields .= "\$table->$type('$field')$nullable$default;\n\t\t\t";
-                    }
-                }
-
-                $this->criaMigration($tableName, $schemaFields);
-                // Aguarda 1 segundo para garantir timestamps únicos
-                sleep(1);
-            }
-        } elseif ($driver === 'pgsql') {
-
-            $schemaName = DB::getDatabaseName();
-
-            $tables = DB::select("SELECT table_name FROM information_schema.tables WHERE table_schema = $schemaName AND table_type='BASE TABLE'");
-
-            foreach ($tables as $table) {
-                $tableName = $table->table_name;
-
-                // Pular a tabela de migrations
-                if ($tableName === 'migrations') {
-                    continue;
-                }
-
-                $this->info("Gerando migration para a tabela: $tableName");
-
-                // Recupera as colunas da tabela no PostgreSQL
-                $columns = DB::select(
-                    "SELECT column_name, data_type, is_nullable, column_default
-                     FROM information_schema.columns
-                     WHERE table_schema = $schemaName AND table_name = ?",
-                     [$tableName]
-                );
-                $schemaFields = "";
-
-                foreach ($columns as $column) {
-                    // Propriedades da coluna: column_name, data_type, is_nullable, column_default
-                    $field = $column->column_name;
-                    $type = $this->mapColumnType($column->data_type, $driver);
-                    $nullable = ($column->is_nullable === "YES") ? "->nullable()" : "";
-                    $default = ($column->column_default !== null) ? "->default('" . addslashes($column->column_default) . "')" : "";
-
-                    // Verifica se a coluna é serial (auto incremento) verificando 'nextval' na coluna default
-                    if ($column->column_default !== null && strpos($column->column_default, 'nextval') !== false) {
-                        $schemaFields .= "\$table->increments('$field');\n\t\t\t";
-                    } else {
-                        $schemaFields .= "\$table->$type('$field')$nullable$default;\n\t\t\t";
-                    }
-                }
-
-                $this->criaMigration($tableName, $schemaFields);
-                // Aguarda 1 segundo para garantir timestamps únicos
-                sleep(1);
-            }
-        } else {
-            $this->error("Driver '$driver' não suportado.");
-            return;
-        }
-
+        $driver    = Config::get('database.default');
+        $generator = $selector->select($driver);
+        $generator->generate();
+        
+        $this->info("Migrations geradas para o driver '{$driver}'.");
         $this->info("Geração de migrations concluída!");
-    }
-
-    /**
-     * Cria o arquivo de migration com o conteúdo fornecido.
-     *
-     * @param string $tableName
-     * @param string $schemaFields
-     * @return void
-     */
-    protected function criaMigration($tableName, $schemaFields)
-    {
-        $migrationClassName = 'Create' . Str::studly($tableName) . 'Table';
-        $migrationFileName = date('Y_m_d_His') . '_create_' . $tableName . '_table.php';
-        $migrationPath = base_path('database/migrations/' . $migrationFileName);
-
-        $content = "<?php
-
-use Illuminate\\Database\\Migrations\\Migration;
-use Illuminate\\Database\\Schema\\Blueprint;
-use Illuminate\\Support\\Facades\\Schema;
-
-return new class extends Migration {
-    /**
-     * Executa as migrations.
-     *
-     * @return void
-     */
-    public function up()
-    {
-        Schema::create('$tableName', function (Blueprint \$table) {
-            $schemaFields
-            \$table->timestamps();
-        });
-    }
-
-    /**
-     * Reverte as migrations.
-     *
-     * @return void
-     */
-    public function down()
-    {
-        Schema::dropIfExists('$tableName');
-    }
-};
-";
-
-        file_put_contents($migrationPath, $content);
-        $this->info("Migration gerada: $migrationFileName");
-    }
-
-    /**
-     * Mapeia o tipo da coluna do banco para o método de migration do Laravel.
-     *
-     * @param string $dbType
-     * @param string $driver
-     * @return string
-     */
-    protected function mapColumnType($dbType, $driver)
-    {
-        if ($driver === 'mysql') {
-            if (preg_match('/^int/', $dbType)) {
-                return 'integer';
-            } elseif (preg_match('/^varchar/', $dbType)) {
-                return 'string';
-            } elseif (preg_match('/^text/', $dbType)) {
-                return 'text';
-            } elseif (preg_match('/^datetime/', $dbType)) {
-                return 'dateTime';
-            } elseif (preg_match('/^date/', $dbType)) {
-                return 'date';
-            } elseif (preg_match('/^decimal/', $dbType)) {
-                return 'decimal';
-            } else {
-                return 'string';
-            }
-        } elseif ($driver === 'pgsql') {
-            // Para PostgreSQL
-            if (in_array($dbType, ['integer', 'bigint', 'smallint'])) {
-                return 'integer';
-            } elseif (strpos($dbType, 'character varying') !== false || $dbType === 'varchar') {
-                return 'string';
-            } elseif (strpos($dbType, 'text') !== false) {
-                return 'text';
-            } elseif (strpos($dbType, 'timestamp') !== false) {
-                return 'dateTime';
-            } elseif ($dbType === 'date') {
-                return 'date';
-            } elseif (in_array($dbType, ['numeric', 'decimal'])) {
-                return 'decimal';
-            } else {
-                return 'string';
-            }
-        } else {
-            return 'string';
-        }
     }
 }

--- a/src/Contracts/MigrationGeneratorInterface.php
+++ b/src/Contracts/MigrationGeneratorInterface.php
@@ -4,6 +4,19 @@ namespace Migrations\MigrationsGenerator\Contracts;
 
 interface MigrationGeneratorInterface
 {
+    /**
+     * Gera as migrations para o banco de dados.
+     *
+     * @return void
+     */
     public function generate(): void;
+
+    /**
+     * Mapeia o tipo de coluna do banco de dados para o tipo correspondente no Laravel.
+     *
+     * @param string $dbType Tipo da coluna no banco de dados
+     * @param string $driver Nome do driver do banco de dados (mysql, mariadb, pgsql)
+     * @return string Tipo de coluna correspondente no Laravel
+     */
     public function mapColumnType(string $dbType, string $driver): string;
 }

--- a/src/Contracts/MigrationGeneratorInterface.php
+++ b/src/Contracts/MigrationGeneratorInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Migrations\MigrationsGenerator\Contracts;
+
+interface MigrationGeneratorInterface
+{
+    public function generate(): void;
+    public function mapColumnType(string $dbType, string $driver): string;
+}

--- a/src/Drivers/MariaDBGenerator.php
+++ b/src/Drivers/MariaDBGenerator.php
@@ -20,6 +20,11 @@ class MariaDBGenerator implements MigrationGeneratorInterface
         $this->migration = new GenerateMigrations;
     }
 
+    /**
+     * Gera as migrations para todas as tabelas do banco de dados MariaDB.
+     *
+     * @return void
+     */
     public function generate(): void
     {
         $databaseName = DB::getDatabaseName();
@@ -34,7 +39,7 @@ class MariaDBGenerator implements MigrationGeneratorInterface
                 continue;
             }
 
-            echo Message::info("Gerando migration para a tabela: $tableName");
+            echo Message::info($tableName, "Gerando migration para a tabela:");
 
             // Recupera as colunas da tabela no MySQL
             $columns = DB::select("SHOW COLUMNS FROM `$tableName`");
@@ -60,6 +65,13 @@ class MariaDBGenerator implements MigrationGeneratorInterface
         }
     }
 
+    /**
+     * Mapeia o tipo de coluna do banco de dados para o tipo de coluna do Laravel.
+     *
+     * @param string $dbType Tipo da coluna no banco de dados
+     * @param string $driver Nome do driver do banco de dados (mysql, mariadb, pgsql)
+     * @return string Tipo de coluna correspondente no Laravel
+     */
     public function mapColumnType(string $dbType, string $driver): string
     {
         if (preg_match('/^int/', $dbType)) {

--- a/src/Drivers/MariaDBGenerator.php
+++ b/src/Drivers/MariaDBGenerator.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Migrations\MigrationsGenerator\Drivers;
+
+use Illuminate\Support\Facades\DB;
+use Migrations\MigrationsGenerator\Contracts\MigrationGeneratorInterface;
+use Migrations\MigrationsGenerator\Message;
+use Migrations\MigrationsGenerator\Services\GenerateMigrations;
+use Migrations\MigrationsGenerator\Services\SkipMigrationsTableFilter;
+
+class MariaDBGenerator implements MigrationGeneratorInterface
+{
+    protected SkipMigrationsTableFilter $filter;
+
+    protected GenerateMigrations $migration;
+
+    public function __construct()
+    {
+        $this->filter = new SkipMigrationsTableFilter;
+        $this->migration = new GenerateMigrations;
+    }
+
+    public function generate(): void
+    {
+        $databaseName = DB::getDatabaseName();
+        $tables = DB::select('SHOW TABLES');
+        $tablesKey = "Tables_in_$databaseName";
+
+        foreach ($tables as $table) {
+            $tableName = $table->$tablesKey;
+
+            // Pular tabelas que devem ser ignoradas
+            if ($this->filter->shouldSkip($tableName)) {
+                continue;
+            }
+
+            echo Message::info("Gerando migration para a tabela: $tableName");
+
+            // Recupera as colunas da tabela no MySQL
+            $columns = DB::select("SHOW COLUMNS FROM `$tableName`");
+            $schemaFields = '';
+
+            foreach ($columns as $column) {
+                // Propriedades da coluna: Field, Type, Null, Key, Default, Extra
+                $field = $column->Field;
+                $type = $this->mapColumnType($column->Type, 'mysql');
+                $nullable = ($column->Null === 'YES') ? '->nullable()' : '';
+                $default = ($column->Default !== null) ? "->default('".addslashes($column->Default)."')" : '';
+
+                // Se a coluna for primary key auto-increment, use o método increments
+                if ($column->Key === 'PRI' && strpos($column->Extra, 'auto_increment') !== false) {
+                    $schemaFields .= "\$table->increments('$field');\n\t\t\t";
+                } else {
+                    $schemaFields .= "\$table->$type('$field')$nullable$default;\n\t\t\t";
+                }
+            }
+
+            $this->migration->generate($tableName, $schemaFields);
+            sleep(1);
+        }
+    }
+
+    public function mapColumnType(string $dbType, string $driver): string
+    {
+        if (preg_match('/^int/', $dbType)) {
+            return 'integer';
+        } elseif (preg_match('/^varchar/', $dbType)) {
+            return 'string';
+        } elseif (preg_match('/^text/', $dbType)) {
+            return 'text';
+        } elseif (preg_match('/^datetime/', $dbType)) {
+            return 'dateTime';
+        } elseif (preg_match('/^date/', $dbType)) {
+            return 'date';
+        } elseif (preg_match('/^decimal/', $dbType)) {
+            return 'decimal';
+        } else {
+            return 'string';
+        }
+    }
+}

--- a/src/Drivers/MySqlGenerator.php
+++ b/src/Drivers/MySqlGenerator.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Migrations\MigrationsGenerator\Drivers;
+
+use Illuminate\Support\Facades\DB;
+use Migrations\MigrationsGenerator\Contracts\MigrationGeneratorInterface;
+use Migrations\MigrationsGenerator\Message;
+use Migrations\MigrationsGenerator\Services\GenerateMigrations;
+use Migrations\MigrationsGenerator\Services\SkipMigrationsTableFilter;
+
+class MySqlGenerator implements MigrationGeneratorInterface
+{
+    protected SkipMigrationsTableFilter $filter;
+
+    protected GenerateMigrations $migration;
+
+    public function __construct()
+    {
+        $this->filter = new SkipMigrationsTableFilter;
+        $this->migration = new GenerateMigrations;
+    }
+
+    public function generate(): void
+    {
+        $tables = DB::connection()
+            ->getDoctrineSchemaManager()
+            ->listTableNames();
+
+        foreach ($tables as $tableName) {
+
+            // Pular tabelas que devem ser ignoradas
+            if ($this->filter->shouldSkip($tableName)) {
+                continue;
+            }
+
+            echo Message::info("Gerando migration para a tabela: $tableName");
+
+            // Recupera as colunas da tabela no MySQL
+            $columns = DB::select("SHOW COLUMNS FROM `$tableName`");
+            $schemaFields = '';
+
+            foreach ($columns as $column) {
+                // Propriedades da coluna: Field, Type, Null, Key, Default, Extra
+                $field = $column->Field;
+                $type = $this->mapColumnType($column->Type, 'mysql');
+                $nullable = ($column->Null === 'YES') ? '->nullable()' : '';
+                $default = ($column->Default !== null) ? "->default('".addslashes($column->Default)."')" : '';
+
+                // Se a coluna for primary key auto-increment, use o método increments
+                if ($column->Key === 'PRI' && strpos($column->Extra, 'auto_increment') !== false) {
+                    $schemaFields .= "\$table->increments('$field');\n\t\t\t";
+                } else {
+                    $schemaFields .= "\$table->$type('$field')$nullable$default;\n\t\t\t";
+                }
+            }
+
+            $this->migration->generate($tableName, $schemaFields);
+            sleep(1);
+        }
+    }
+
+    public function mapColumnType(string $dbType, string $driver): string
+    {
+        if (preg_match('/^int/', $dbType)) {
+            return 'integer';
+        } elseif (preg_match('/^varchar/', $dbType)) {
+            return 'string';
+        } elseif (preg_match('/^text/', $dbType)) {
+            return 'text';
+        } elseif (preg_match('/^datetime/', $dbType)) {
+            return 'dateTime';
+        } elseif (preg_match('/^date/', $dbType)) {
+            return 'date';
+        } elseif (preg_match('/^decimal/', $dbType)) {
+            return 'decimal';
+        } else {
+            return 'string';
+        }
+    }
+}

--- a/src/Drivers/MySqlGenerator.php
+++ b/src/Drivers/MySqlGenerator.php
@@ -20,6 +20,11 @@ class MySqlGenerator implements MigrationGeneratorInterface
         $this->migration = new GenerateMigrations;
     }
 
+    /**
+     * Gera as migrations para todas as tabelas do banco de dados MySQL.
+     *
+     * @return void
+     */
     public function generate(): void
     {
         $tables = DB::connection()
@@ -33,7 +38,7 @@ class MySqlGenerator implements MigrationGeneratorInterface
                 continue;
             }
 
-            echo Message::info("Gerando migration para a tabela: $tableName");
+            echo Message::info($tableName, "Gerando migration para a tabela:");
 
             // Recupera as colunas da tabela no MySQL
             $columns = DB::select("SHOW COLUMNS FROM `$tableName`");
@@ -59,6 +64,13 @@ class MySqlGenerator implements MigrationGeneratorInterface
         }
     }
 
+    /**
+     * Mapeia o tipo de coluna do banco de dados para o tipo de coluna do Laravel.
+     *
+     * @param string $dbType Tipo da coluna no banco de dados
+     * @param string $driver Nome do driver do banco de dados (mysql, mariadb, pgsql)
+     * @return string Tipo de coluna correspondente no Laravel
+     */
     public function mapColumnType(string $dbType, string $driver): string
     {
         if (preg_match('/^int/', $dbType)) {

--- a/src/Drivers/PostgresGenerator.php
+++ b/src/Drivers/PostgresGenerator.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Migrations\MigrationsGenerator\Drivers;
+
+use Illuminate\Support\Facades\DB;
+use Migrations\MigrationsGenerator\Contracts\MigrationGeneratorInterface;
+use Migrations\MigrationsGenerator\Message;
+use Migrations\MigrationsGenerator\Services\GenerateMigrations;
+use Migrations\MigrationsGenerator\Services\SkipMigrationsTableFilter;
+
+class PostgresGenerator implements MigrationGeneratorInterface
+{
+    protected SkipMigrationsTableFilter $filter;
+
+    protected GenerateMigrations $migration;
+
+    public function __construct()
+    {
+        $this->filter = new SkipMigrationsTableFilter;
+        $this->migration = new GenerateMigrations;
+    }
+
+    public function generate(): void
+    {
+        $schemaName = DB::getDatabaseName();
+
+        $tables = DB::select("SELECT table_name FROM information_schema.tables WHERE table_schema = $schemaName AND table_type='BASE TABLE'");
+
+        foreach ($tables as $table) {
+            $tableName = $table->table_name;
+
+            // Pular tabelas que devem ser ignoradas
+            if ($this->filter->shouldSkip($tableName)) {
+                continue;
+            }
+
+            echo Message::info("Gerando migration para a tabela: $tableName");
+
+            // Recupera as colunas da tabela no PostgreSQL
+            $columns = DB::select(
+                "SELECT column_name, data_type, is_nullable, column_default
+                    FROM information_schema.columns
+                    WHERE table_schema = $schemaName AND table_name = ?",
+                [$tableName]
+            );
+            $schemaFields = '';
+
+            foreach ($columns as $column) {
+                // Propriedades da coluna: column_name, data_type, is_nullable, column_default
+                $field = $column->column_name;
+                $type = $this->mapColumnType($column->data_type, 'pgsql');
+                $nullable = ($column->is_nullable === 'YES') ? '->nullable()' : '';
+                $default = ($column->column_default !== null) ? "->default('".addslashes($column->column_default)."')" : '';
+
+                // Verifica se a coluna é serial (auto incremento) verificando 'nextval' na coluna default
+                if ($column->column_default !== null && strpos($column->column_default, 'nextval') !== false) {
+                    $schemaFields .= "\$table->increments('$field');\n\t\t\t";
+                } else {
+                    $schemaFields .= "\$table->$type('$field')$nullable$default;\n\t\t\t";
+                }
+            }
+
+            $this->migration->generate($tableName, $schemaFields);
+            sleep(1);
+        }
+    }
+
+    public function mapColumnType(string $dbType, string $driver): string
+    {
+        if (in_array($dbType, ['integer', 'bigint', 'smallint'])) {
+            return 'integer';
+        } elseif (strpos($dbType, 'character varying') !== false || $dbType === 'varchar') {
+            return 'string';
+        } elseif (strpos($dbType, 'text') !== false) {
+            return 'text';
+        } elseif (strpos($dbType, 'timestamp') !== false) {
+            return 'dateTime';
+        } elseif ($dbType === 'date') {
+            return 'date';
+        } elseif (in_array($dbType, ['numeric', 'decimal'])) {
+            return 'decimal';
+        } else {
+            return 'string';
+        }
+    }
+}

--- a/src/Drivers/PostgresGenerator.php
+++ b/src/Drivers/PostgresGenerator.php
@@ -20,6 +20,11 @@ class PostgresGenerator implements MigrationGeneratorInterface
         $this->migration = new GenerateMigrations;
     }
 
+    /**
+     * Gera as migrations para todas as tabelas do banco de dados PostgreSQL.
+     *
+     * @return void
+     */
     public function generate(): void
     {
         $schemaName = DB::getDatabaseName();
@@ -34,7 +39,7 @@ class PostgresGenerator implements MigrationGeneratorInterface
                 continue;
             }
 
-            echo Message::info("Gerando migration para a tabela: $tableName");
+            echo Message::info($tableName, "Gerando migration para a tabela:");
 
             // Recupera as colunas da tabela no PostgreSQL
             $columns = DB::select(
@@ -65,6 +70,13 @@ class PostgresGenerator implements MigrationGeneratorInterface
         }
     }
 
+    /**
+     * Mapeia o tipo de coluna do PostgreSQL para o tipo correspondente no Laravel.
+     *
+     * @param string $dbType Tipo da coluna no banco de dados
+     * @param string $driver Nome do driver (neste caso, 'pgsql')
+     * @return string Tipo correspondente no Laravel
+     */
     public function mapColumnType(string $dbType, string $driver): string
     {
         if (in_array($dbType, ['integer', 'bigint', 'smallint'])) {

--- a/src/Message.php
+++ b/src/Message.php
@@ -7,44 +7,48 @@ class Message
     /**
      * Retorna mensagem de informação formatada para o terminal.
      *
-     * @param string $message
-     * @return string
+     * @param string $message Mensagem a ser exibida
+     * @param string $title Título opcional para a mensagem
+     * @return string Mensagem formatada
      */
-    public static function info(string $message): string
+    public static function info(string $message, string $title = ''): string
     {
-        return "\033[34m{$message}\033[0m" . PHP_EOL;
+        return "{$title} \033[34m{$message}\033[0m".PHP_EOL;
     }
 
     /**
      * Retorna mensagem de sucesso formatada para o terminal.
      *
-     * @param string $message
-     * @return string
+     * @param string $message Mensagem a ser exibida
+     * @param string $title Título opcional para a mensagem
+     * @return string Mensagem formatada
      */
-    public static function success(string $message): string
+    public static function success(string $message, string $title = ''): string
     {
-        return "\033[32m{$message}\033[0m" . PHP_EOL;
+        return "{$title} \033[32m{$message}\033[0m".PHP_EOL;
     }
 
     /**
      * Retorna mensagem de aviso formatada para o terminal.
      *
-     * @param string $message
-     * @return string
+     * @param string $message Mensagem a ser exibida
+     * @param string $title Título opcional para a mensagem
+     * @return string Mensagem formatada
      */
-    public static function warning(string $message): string
+    public static function warning(string $message, string $title = ''): string
     {
-        return "\033[33m{$message}\033[0m" . PHP_EOL;
+        return "{$title} \033[33m{$message}\033[0m".PHP_EOL;
     }
 
     /**
      * Retorna mensagem de erro formatada para o terminal.
      *
-     * @param string $message
-     * @return string
+     * @param string $message Mensagem a ser exibida
+     * @param string $title Título opcional para a mensagem
+     * @return string Mensagem formatada
      */
-    public static function error(string $message): string
+    public static function error(string $message, string $title = ''): string
     {
-        return "\033[31m{$message}\033[0m" . PHP_EOL;
+        return "{$title} \033[31m{$message}\033[0m".PHP_EOL;
     }
 }

--- a/src/Message.php
+++ b/src/Message.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Migrations\MigrationsGenerator;
+
+class Message
+{
+    /**
+     * Retorna mensagem de informação formatada para o terminal.
+     *
+     * @param string $message
+     * @return string
+     */
+    public static function info(string $message): string
+    {
+        return "\033[34m{$message}\033[0m" . PHP_EOL;
+    }
+
+    /**
+     * Retorna mensagem de sucesso formatada para o terminal.
+     *
+     * @param string $message
+     * @return string
+     */
+    public static function success(string $message): string
+    {
+        return "\033[32m{$message}\033[0m" . PHP_EOL;
+    }
+
+    /**
+     * Retorna mensagem de aviso formatada para o terminal.
+     *
+     * @param string $message
+     * @return string
+     */
+    public static function warning(string $message): string
+    {
+        return "\033[33m{$message}\033[0m" . PHP_EOL;
+    }
+
+    /**
+     * Retorna mensagem de erro formatada para o terminal.
+     *
+     * @param string $message
+     * @return string
+     */
+    public static function error(string $message): string
+    {
+        return "\033[31m{$message}\033[0m" . PHP_EOL;
+    }
+}

--- a/src/MigrationsGeneratorServiceProvider.php
+++ b/src/MigrationsGeneratorServiceProvider.php
@@ -8,6 +8,11 @@ use Migrations\MigrationsGenerator\Console\GenerateMigrationsCommand;
 
 class MigrationsGeneratorServiceProvider extends ServiceProvider
 {
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
     public function boot()
     {
         if ($this->app->runningInConsole()) {
@@ -17,11 +22,15 @@ class MigrationsGeneratorServiceProvider extends ServiceProvider
         }
     }
 
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
     public function register()
     {
         if ($this->app->environment() !== 'production') {
             $this->app->bind(
-                DriverSelector::class,
                 DriverSelector::class
             );
         }

--- a/src/MigrationsGeneratorServiceProvider.php
+++ b/src/MigrationsGeneratorServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Migrations\MigrationsGenerator;
 
 use Illuminate\Support\ServiceProvider;
+use Migrations\MigrationsGenerator\Services\DriverSelector;
 use Migrations\MigrationsGenerator\Console\GenerateMigrationsCommand;
 
 class MigrationsGeneratorServiceProvider extends ServiceProvider
@@ -18,9 +19,11 @@ class MigrationsGeneratorServiceProvider extends ServiceProvider
 
     public function register()
     {
-        // Aqui você pode mesclar configurações ou registrar bindings se necessário.
         if ($this->app->environment() !== 'production') {
-
+            $this->app->bind(
+                DriverSelector::class,
+                DriverSelector::class
+            );
         }
     }
 }

--- a/src/Services/BasePath.php
+++ b/src/Services/BasePath.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Migrations\MigrationsGenerator\Services;
+
+use Migrations\MigrationsGenerator\Message;
+
+class BasePath
+{
+    /**
+     * Retorna o caminho completo do arquivo de migration.
+     *
+     * @param string $fileName Nome do arquivo de migration
+     * @return string Caminho completo do arquivo
+     */
+    public function file(string $fileName): string
+    {
+        try {
+            if (!is_dir(base_path('database/migrations'))) {
+                mkdir(base_path('database/migrations'), 0755, true);
+            }
+        } catch (\Exception $e) {
+            echo Message::error("Erro ao criar o diretório de migrations: " . $e->getMessage());
+            die;
+        }
+
+        return base_path('database/migrations/' . $fileName);
+    }
+}

--- a/src/Services/DriverSelector.php
+++ b/src/Services/DriverSelector.php
@@ -9,6 +9,13 @@ use Migrations\MigrationsGenerator\Drivers\PostgresGenerator;
 
 class DriverSelector
 {
+    /**
+     * Seleciona o gerador de migrations baseado no driver do banco de dados.
+     *
+     * @param string $driver Nome do driver do banco de dados (mysql, mariadb, pgsql)
+     * @return MigrationGeneratorInterface Instância do gerador de migrations correspondente
+     * @throws \InvalidArgumentException Se o driver não for suportado
+     */
     public function select(string $driver): MigrationGeneratorInterface
     {
         return match ($driver) {

--- a/src/Services/DriverSelector.php
+++ b/src/Services/DriverSelector.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Migrations\MigrationsGenerator\Services;
+
+use Migrations\MigrationsGenerator\Contracts\MigrationGeneratorInterface;
+use Migrations\MigrationsGenerator\Drivers\MariaDBGenerator;
+use Migrations\MigrationsGenerator\Drivers\MySqlGenerator;
+use Migrations\MigrationsGenerator\Drivers\PostgresGenerator;
+
+class DriverSelector
+{
+    public function select(string $driver): MigrationGeneratorInterface
+    {
+        return match ($driver) {
+            'mysql' => new MySqlGenerator,
+            'mariadb' => new MariaDBGenerator,
+            'pgsql' => new PostgresGenerator,
+            default => throw new \InvalidArgumentException("Driver inválido: $driver"),
+        };
+    }
+}

--- a/src/Services/GenerateMigrations.php
+++ b/src/Services/GenerateMigrations.php
@@ -1,0 +1,52 @@
+<?php
+namespace Migrations\MigrationsGenerator\Services;
+
+use Illuminate\Support\Str;
+use Migrations\MigrationsGenerator\Message;
+
+class GenerateMigrations
+{
+    public function generate($tableName, $schemaFields)
+    {
+        $migrationClassName = 'Create' . Str::studly($tableName) . 'Table';
+        $migrationFileName = date('Y_m_d_His') . '_create_' . $tableName . '_table.php';
+        $migrationPath = base_path('database/migrations/' . $migrationFileName);
+
+        $content = "<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Migrations\MigrationsGenerator\Message;
+
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Support\\Facades\\Schema;
+
+return new class extends Migration {
+    /**
+     * Executa as migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('$tableName', function (Blueprint \$table) {
+            $schemaFields
+            \$table->timestamps();
+        });
+    }
+
+    /**
+     * Reverte as migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('$tableName');
+    }
+};";
+
+        file_put_contents($migrationPath, $content);
+        echo Message::info("Migration gerada: $migrationFileName");
+    }
+
+}

--- a/src/Services/GenerateMigrations.php
+++ b/src/Services/GenerateMigrations.php
@@ -1,16 +1,21 @@
 <?php
 namespace Migrations\MigrationsGenerator\Services;
 
-use Illuminate\Support\Str;
 use Migrations\MigrationsGenerator\Message;
 
 class GenerateMigrations
 {
-    public function generate($tableName, $schemaFields)
+    /**
+     * Gera o arquivo de migration para a criação de uma tabela.
+     *
+     * @param string $tableName Nome da tabela a ser criada
+     * @param string $schemaFields Campos da tabela em formato de string
+     * @return void
+     */
+    public function generate($tableName, $schemaFields): void
     {
-        $migrationClassName = 'Create' . Str::studly($tableName) . 'Table';
         $migrationFileName = date('Y_m_d_His') . '_create_' . $tableName . '_table.php';
-        $migrationPath = base_path('database/migrations/' . $migrationFileName);
+        $migrationPath = (new BasePath)->file($migrationFileName);
 
         $content = "<?php
 
@@ -45,8 +50,13 @@ return new class extends Migration {
     }
 };";
 
-        file_put_contents($migrationPath, $content);
-        echo Message::info("Migration gerada: $migrationFileName");
+        try {
+            file_put_contents($migrationPath, $content);
+            echo Message::success($migrationFileName, "Migration criada com sucesso:");
+        } catch (\Exception $e) {
+            echo Message::error("Erro ao criar a migration: " . $e->getMessage());
+            die;
+        }
     }
 
 }

--- a/src/Services/SkipMigrationsTableFilter.php
+++ b/src/Services/SkipMigrationsTableFilter.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Migrations\MigrationsGenerator\Services;
+
+/**
+ * Filtra tabelas que não devem ser processadas pelo gerador de migrations.
+ */
+class SkipMigrationsTableFilter
+{
+    /**
+     * Verifica se a tabela deve ser pulada.
+     *
+     * @return bool Retorna true se deve pular (skip)
+     */
+    public function shouldSkip(string $tableName): bool
+    {
+        return $tableName === 'migrations';
+    }
+}


### PR DESCRIPTION
Implements a new feature to automatically generate Laravel migrations based on the existing database schema.

Key improvements:
- Supports MySQL, MariaDB, and PostgreSQL databases.
- Introduces a driver selection mechanism for database-specific schema retrieval.
- Adds an option to skip the 'migrations' table.
- Enhances the command-line interface for streamlined migration generation.

The changes address the need for a more efficient way to create migrations from existing database structures, reducing manual effort and potential inconsistencies.